### PR TITLE
Add support for running on Nitrous

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ This project contains a quick starter kit for **Facebook React** Single Page App
 * [go-bindata](https://github.com/jteeuwen/go-bindata/)
 * [srlt](https://github.com/olebedev/srlt)
 
-Note that probably not works at windows.
+Note that probably does not work on Windows - you can instead create a free
+development environment to get started using this starter kit in the cloud on
+[Nitrous](https://www.nitrous.io/):
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
 
 ## Project structure
 
@@ -93,6 +99,17 @@ client
 The client app will be compiled into `server/data/static/build/`.  Then it will be embedded into go package via _go-bindata_. After that the package will be compiled into binary.
 
 **Convention**: javascript app should declare [_main_](https://github.com/olebedev/go-starter-kit/blob/master/client/index.js#L4) function right in the global namespace. It will used to render the app at the server side.
+
+## Nitrous Quickstart
+
+You can quickly create a free development environment to get started using this
+starter kit in the cloud on [Nitrous](https://www.nitrous.io/):
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start Go Starter Kit via `Run > Start Go Starter Kit` and access your site via `Preview > 5001`.
 
 ## Install
 

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your go-starter-kit project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start Go Starter Kit via "Run > Start Go Starter Kit"
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 5001".

--- a/nitrous-post-create.sh
+++ b/nitrous-post-create.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+mkdir -p $GOPATH/src/github.com/nitrous-io
+mv ~/code/go-starter-kit $GOPATH/src/github.com/nitrous-io/
+ln -s $GOPATH/src/github.com/nitrous-io/go-starter-kit ~/code/go-starter-kit
+
+cd $GOPATH/src/github.com/nitrous-io/go-starter-kit
+
+echo 'Installing dependencies using npm - this might take awhile...'
+npm install --no-progress
+
+echo 'Installing slrt...'
+go get github.com/olebedev/srlt
+echo 'Unpacking Golang dependencies...'
+srlt restore
+
+echo 'Installing github.com/jteeuwen/go-bindata...'
+go get github.com/jteeuwen/go-bindata/...
+
+echo 'Installing fswatch...'
+cd ~
+wget https://github.com/emcrisostomo/fswatch/releases/download/1.8.0/fswatch-1.8.0.tar.gz
+tar xf fswatch-1.8.0.tar.gz
+cd fstwatch-1.8.0
+./configure
+make
+make install
+sudo ldconfig
+rm -rf fswatch-1.8.0.tar.gz fswatch-1.8.0

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,7 @@
+{
+  "template": "golang",
+  "ports": [5001],
+  "scripts": {
+    "Start Go Starter Kit": "cd $GOPATH/src/github.com/nitrous-io/go-starter-kit && make serve"
+  }
+}


### PR DESCRIPTION
This allows developers to conveniently run this starter kit in the "cloud" (where cloud == [Nitrous](https://www.nitrous.io)).

We're calling it [Nitrous Quickstarts](https://community.nitrous.io/posts/nitrous-quickstarts) and it basically provides an easy way to run apps without requiring developers to install anything locally - installing the `fswatch` dependency was slightly tricky on Ubuntu (this is where Homebrew is great).

Anyways, I'm featuring go-starter-kit on [this page](https://www.nitrous.io/quickstarts/) because I think it's a great use case for Nitrous Quickstarts :smile_cat: 
