### PR TITLE
fix import echo

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/labstack/echo"
+	"gopkg.in/labstack/echo.v1"
 )
 
 // API is a defined as struct bundle

--- a/server/app.go
+++ b/server/app.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/elazarl/go-bindata-assetfs"
 	"github.com/itsjamie/go-bindata-templates"
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
 	"github.com/nu7hatch/gouuid"
 	"github.com/olebedev/config"
+	"gopkg.in/labstack/echo.v1"
+	"gopkg.in/labstack/echo.v1/middleware"
 )
 
 // App struct.

--- a/server/react.go
+++ b/server/react.go
@@ -11,8 +11,8 @@ import (
 	"gopkg.in/olebedev/go-duktape-fetch.v2"
 	"gopkg.in/olebedev/go-duktape.v2"
 
-	"github.com/labstack/echo"
 	"github.com/nu7hatch/gouuid"
+	"gopkg.in/labstack/echo.v1"
 )
 
 // React struct is contains duktape


### PR DESCRIPTION
Nice starter-kit! I hope it will be helpful.
i did have some trouble with "echo" package from github.
I found the solution here https://github.com/labstack/echo/issues/390
That's error log:
```
/home/jaime/PROJECTS/backend_projects/golang/bin/go-bindata -pkg=main -prefix=server/data -debug -o=server/bindata.go server/data/...
cat: .pid: No such file or directory
/bin/sh: 1: kill: Usage: kill [-s sigspec | -signum | -sigspec] [pid | job]... or
kill -l [exitstatus]
# github.com/go-starter-kit/server
server/api.go:16: cannot use api.ConfHandler (type func(*echo.Context) error) as type echo.HandlerFunc in argument to group.Get
server/api.go:21: c.Get undefined (type *echo.Context is pointer to interface, not interface)
server/api.go:23: c.JSON undefined (type *echo.Context is pointer to interface, not interface)
server/app.go:68: cannot use engine (type *echo.Echo) as type http.Handler in argument to NewReact:
	*echo.Echo does not implement http.Handler (wrong type for ServeHTTP method)
		have ServeHTTP(engine.Request, engine.Response)
		want ServeHTTP(http.ResponseWriter, *http.Request)
server/app.go:79: c.Set undefined (type *echo.Context is pointer to interface, not interface)
server/app.go:86: c.Set undefined (type *echo.Context is pointer to interface, not interface)
server/app.go:92: c.Redirect undefined (type *echo.Context is pointer to interface, not interface)
server/app.go:115: cannot use c (type *echo.Context) as type echo.Context in argument to h:
	*echo.Context is pointer to interface, not interface
server/app.go:120: c.Request undefined (type *echo.Context is pointer to interface, not interface)
server/app.go:121: c.Response undefined (type *echo.Context is pointer to interface, not interface)
server/app.go:121: too many errors
Makefile:27: recipe for target '/home/jaime/PROJECTS/backend_projects/golang/bin/go-starter-kit' failed
make: *** [/home/jaime/PROJECTS/backend_projects/golang/bin/go-starter-kit] Error 2
```
