### PR TITLE
Add install command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ APP_NAME      = $(shell pwd | sed 's:.*/::')
 TARGET        = $(BIN)/$(APP_NAME)
 GIT_HASH      = $(shell git rev-parse HEAD)
 LDFLAGS       = -w -X main.commitHash=$(GIT_HASH)
+SRLT         := $(shell command -v srlt 2> /dev/null)
 
 build: $(ON) $(GO_BINDATA) clean $(TARGET)
 
@@ -54,3 +55,12 @@ $(BINDATA):
 lint:
 	@eslint client || true
 	@golint $(GO_FILES) || true
+
+install:
+	@npm install
+
+ifdef SRLT
+	@srlt restore
+else
+	$(warning "Skipping installation of Go dependencies: srlt is not installed")
+endif

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ $ srlt restore
 
 This command will install dependencies into `./vendor/` folder located in root.
 
+You can also install all dependencies at once by running:
+
+```
+$ make install
+```
+
 ## Run development
 
 Start dev server:


### PR DESCRIPTION
Add `install` command to the Makefile.

From README.md:
> You can also install all dependencies at once by running:
> 
> ```
> $ make install
> ```