### PR TITLE
Use local ESLint install by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ $(BINDATA):
 	$(GO_BINDATA) $(BINDATA_FLAGS) -o=$@ server/data/...
 
 lint:
-	@eslint client || true
+	@npm run eslint || true
 	@golint $(GO_FILES) || true
 
 install:

--- a/client/reducers.js
+++ b/client/reducers.js
@@ -3,10 +3,10 @@ import { SET_CONFIG } from './actions';
 
 function config(state = {}, action) {
   switch (action.type) {
-    case SET_CONFIG:
-      return action.config;
-    default:
-      return state;
+  case SET_CONFIG:
+    return action.config;
+  default:
+    return state;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "scripts": {
+    "eslint": "eslint client",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "olebedev",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-preset-stage-0": "6.5.0",
     "css-loader": "^0.23.1",
     "cssrecipes-defaults": "^0.5.0",
+    "eslint": "^3.15.0",
     "eslint-plugin-react": "^3.16.1",
     "expose-loader": "^0.7.1",
     "express": "^4.13.4",
@@ -87,9 +88,12 @@
       "browser": true,
       "node": true
     },
-    "ecmaFeatures": {
-      "jsx": true,
-      "modules": true
+    "parserOptions": {
+      "ecmaFeatures": {
+        "jsx": true,
+        "modules": true
+      },
+      "sourceType": "module"
     },
     "plugins": [
       "react"


### PR DESCRIPTION
I had some issues getting ESLint to work with the default setup so I made some changes to install it locally (into node_modules) and then use that version by default. I also changed the config as the current config had errors for me. I then fixed a lint error in one of the files which ESLint complained about.

These changes helped me get going so I thought I would create a pull request in case they might help others. If you're not interested feel free to just close this - it's quite minor anyway.