### PR TITLE
Enable linting .js files which are not stored in the client directory

### DIFF
--- a/hot.proxy.js
+++ b/hot.proxy.js
@@ -28,12 +28,12 @@ app.use(webpackDevMiddleware(compiler, { noInfo: true, publicPath: config.output
 app.use(webpackHotMiddleware(compiler));
 app.use(proxy('http://localhost:' + port));
 
-port++
+port++;
 
 app.listen(port, function(error) {
   if (error) {
     console.error(error);
   } else {
-    console.info("==> 🌎  Listening on port %s. Open up http://localhost:%s/ in your browser.", port, port);
+    console.info('==> 🌎  Listening on port %s. Open up http://localhost:%s/ in your browser.', port, port);
   }
 });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "scripts": {
-    "eslint": "eslint client",
+    "eslint": "eslint *.js client",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "olebedev",


### PR DESCRIPTION
Some .js files are not stored in the 'client' subdirectory. This PR enables linting of those files as well & fixes a couple of (very minor) lint errors which were detected.